### PR TITLE
fixed max homes limit

### DIFF
--- a/EssentialsPlus/Commands.cs
+++ b/EssentialsPlus/Commands.cs
@@ -276,7 +276,7 @@ namespace EssentialsPlus
 				return;
 			}
 
-			if ((await EssentialsPlus.Homes.GetAllAsync(e.Player)).Count + 1 >= e.Player.Group.GetDynamicPermission(Permissions.HomeSet))
+			if ((await EssentialsPlus.Homes.GetAllAsync(e.Player)).Count - 4 >= e.Player.Group.GetDynamicPermission(Permissions.HomeSet))
 			{
 				e.Player.SendErrorMessage("You have reached your home limit!");
 				return;


### PR DESCRIPTION
superadmin etc. ignored "max home limit"
"normal" players can't use /sethome cause they reached the limit
this little "fix" should be working (tested already) max home limit is now 5 per player